### PR TITLE
Update SDK and Gradle versions & Updated README.md for System Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,25 @@ This project demonstrates how to integrate the Simple DirectMedia Layer (SDL) li
 
 Follow these steps to set up the project:
 
+## System Requirements
+
+The version of Android Studio used in this project is 2024.1.2
+
+Since this project uses an older version of SDL the project requires java version 8. Download it from [OpenJDK](https://www.openlogic.com/openjdk-downloads?field_java_parent_version_target_id=416&field_operating_system_target_id=436&field_architecture_target_id=391&field_java_package_target_id=All) and install it. After installing it, change the JDK which Android Studio is using by going **File > Settings > Build, Execution, Deployment > Build Tools > Gradle** and change the Gradle SDK to the local directory of the JDK like ```C:\Program Files\OpenLogic\jdk-version```.
+
+You need to install the desired Android SDK for the device you want, in this example we are using API level 17, so to install one go to **File > Settings > Languages & Frameworks > C++ > Android SDK** and choose your desired device, in our case since we are using API level 17 we select the option ```Android 4.2 ("Jelly Bean")```
+
+**Note:** This project only was tested in versions of API level 17 and 30.
+
+Lastly what u will need to do is to change the gradle version of the gradle-wrapper.properties to use the version 4.8.1, like this: 
+```
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+```
+
 1. **Clone the repository:**
 
     ```sh
-    git clone https://github.com/victorberdugo1/SDL-Android-Tutorial.git
+    git clone https://github.com/yourusername/SDL-Android-Tutorial.git
     cd SDL-Android-Tutorial
     ```
 

--- a/SDL/build.gradle
+++ b/SDL/build.gradle
@@ -1,15 +1,20 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google() // Add this
+        mavenCentral() // For other dependencies
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        //noinspection GradlePluginVersion
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 allprojects {
     repositories {
+        google() // Add this
+        mavenCentral()
         jcenter()
     }
 }

--- a/SDL/gradle/wrapper/gradle-wrapper.properties
+++ b/SDL/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Wed Dec 11 12:24:07 CVT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
* Updated Gradle wrapper and dependencies to work with newer versions.
* Added instructions for required JDK versions (JDK 8 for Gradle 4.8.1).
* Updated system requirements in the documentation.